### PR TITLE
make status bar style configurable

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -10,6 +10,7 @@ return [
         'theme_color' => '#000000',
         'display' => 'standalone',
         'orientation'=> 'any',
+        'status_bar'=> 'black',
         'icons' => [
             '72x72' => '/images/icons/icon-72x72.png',
             '96x96' => '/images/icons/icon-96x96.png',

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Configure your app name, description, icons and splashes  in `config/laravelpwa.
         'theme_color' => '#000000',
         'display' => 'standalone',
         'orientation' => 'any',
+        'status_bar' => 'black',
         'icons' => [
             '72x72' => '/images/icons/icon-72x72.png',
             '96x96' => '/images/icons/icon-96x96.png',

--- a/Services/ManifestService.php
+++ b/Services/ManifestService.php
@@ -21,6 +21,7 @@ class ManifestService
             'theme_color' => config('laravelpwa.manifest.theme_color'),
             'background_color' => config('laravelpwa.manifest.background_color'),
             'orientation' =>  config('laravelpwa.manifest.orientation'),
+            'status_bar' =>  config('laravelpwa.manifest.status_bar'),
             'splash' =>  config('laravelpwa.manifest.splash')
         ];
 

--- a/resources/views/meta.blade.php
+++ b/resources/views/meta.blade.php
@@ -10,7 +10,7 @@
 
 <!-- Add to homescreen for Safari on iOS -->
 <meta name="apple-mobile-web-app-capable" content="{{ $config['display'] == 'standalone' ? 'yes' : 'no' }}">
-<meta name="apple-mobile-web-app-status-bar-style" content="black">
+<meta name="apple-mobile-web-app-status-bar-style" content="{{  $config['status_bar'] }}">
 <meta name="apple-mobile-web-app-title" content="{{ $config['short_name'] }}">
 <link rel="apple-touch-icon" href="{{ data_get(end($config['icons']), 'src') }}">
 


### PR DESCRIPTION
I make iOS status bar style configurable.

Available options: `black`, `default`, `black-translucent`.

Reference: [Supported Meta Tags](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html)