### PR TITLE
change published view location

### DIFF
--- a/Providers/LaravelPWAServiceProvider.php
+++ b/Providers/LaravelPWAServiceProvider.php
@@ -61,7 +61,7 @@ class LaravelPWAServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = base_path('resources/views/modules/laravelpwa');
+        $viewPath = base_path('resources/views/vendor/laravelpwa');
 
         $sourcePath = __DIR__.'/../resources/views';
 
@@ -70,7 +70,7 @@ class LaravelPWAServiceProvider extends ServiceProvider
         ], 'views');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
-            return $path . '/modules/laravelpwa';
+            return $path . '/vendor/laravelpwa';
         }, \Config::get('view.paths')), [$sourcePath]), 'laravelpwa');
     }
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To customize service worker functionality, update the `public_path/serviceworker
 
 The offline view
 =====
-By default, the offline view is implemented in `resources/views/modules/laravelpwa/offline.blade.php`
+By default, the offline view is implemented in `resources/views/vendor/laravelpwa/offline.blade.php`
 
 ```html
 @extends('layouts.app')


### PR DESCRIPTION
Third-party packages and framework put published views to `resources/views/vendor` directory. 
Laravel community is used to this location. I believe following that practice is more convenient.

Laravel looks for views `resources/views/vendor/laravelpwa` firstly.
Reference: [Package Development](https://laravel.com/docs/6.x/packages#views)