### PR TITLE
Add shortcuts functionality for PWAs

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -57,6 +57,22 @@ return [
             '1668x2388' => '/images/icons/splash-1668x2388.png',
             '2048x2732' => '/images/icons/splash-2048x2732.png',
         ],
+        'shortcuts' => [
+            [
+                'name' => 'Shortcut Link 1',
+                'description' => 'Shortcut Link 1 Description',
+                'url' => '/shortcutlink1',
+                'icons' => [
+                    "src" => "/images/icons/icon-72x72.png",
+                    "purpose" => "any"
+                ]
+            ],
+            [
+                'name' => 'Shortcut Link 2',
+                'description' => 'Shortcut Link 2 Description',
+                'url' => '/shortcutlink2'
+            ]
+        ],
         'custom' => []
     ]
 ];

--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ Configure your app name, description, icons and splashes  in `config/laravelpwa.
             '1668x2388' => '/images/icons/splash-1668x2388.png',
             '2048x2732' => '/images/icons/splash-2048x2732.png',
         ],
+        'shortcuts' => [
+            [
+                'name' => 'Shortcut Link 1',
+                'description' => 'Shortcut Link 1 Description',
+                'url' => '/shortcutlink1',
+                'icons' => [
+                    "src" => "/images/icons/icon-72x72.png",
+                    "purpose" => "any"
+                ]
+            ],
+            [
+                'name' => 'Shortcut Link 2',
+                'description' => 'Shortcut Link 2 Description',
+                'url' => '/shortcutlink2'
+            ]
+        ],
         'custom' => []
     ]
 ```

--- a/Services/ManifestService.php
+++ b/Services/ManifestService.php
@@ -49,8 +49,8 @@ class ManifestService
             }
 
             $basicManifest['shortcuts'][] = [
-                'name' => $shortcut['name'],
-                'description' => $shortcut['description'],
+                'name' => trans($shortcut['name']),
+                'description' => trans($shortcut['description']),
                 'url' => $shortcut['url'],
                 'icons' => [
                         $icon

--- a/Services/ManifestService.php
+++ b/Services/ManifestService.php
@@ -35,6 +35,29 @@ class ManifestService
             ];
         }
 
+        foreach (config('laravelpwa.manifest.shortcuts') as $shortcut) {
+
+            if (array_key_exists("icons", $shortcut)) {
+                $fileInfo = pathinfo($shortcut['icons']['src']);
+                $icon = [
+                    'src' => $shortcut['icons']['src'],
+                    'type' => 'image/' . $fileInfo['extension'],
+                    'purpose' => $shortcut['icons']['purpose']
+                ];
+            } else {
+                $icon = [];
+            }
+
+            $basicManifest['shortcuts'][] = [
+                'name' => $shortcut['name'],
+                'description' => $shortcut['description'],
+                'url' => $shortcut['url'],
+                'icons' => [
+                        $icon
+                    ]
+            ];
+        }
+
         foreach (config('laravelpwa.manifest.custom') as $tag => $value) {
              $basicManifest[$tag] = $value;
         }


### PR DESCRIPTION
Added the possibility to add app shortcuts using the manifest.json [1] on Android/Windows.
Short overview can be found here [2].

Currently only available in Chrome Canary, but i guess/hope it will be "soon" available in the regular version of Chrome too.  A short 


[1] https://w3c.github.io/manifest/#shortcuts-member
[2] https://www.neowin.net/news/chrome-canary-now-lets-pinned-pwas-display-app-shortcuts-on-android-and-windows/


