### PR TITLE
Add deployment command

### DIFF
--- a/Console/DeployManifest.php
+++ b/Console/DeployManifest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace LaravelPWA\Console\Commands;
+
+use File;
+
+use Illuminate\Console\Command;
+use LaravelPWA\Services\ManifestService;
+
+class DeployManifest extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'pwa:manifest-deploy';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deploy the manifest.json into a json file.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+       
+        $output = (new ManifestService)->generate();
+        File::put(public_path("manifest.json"), json_encode($output, JSON_PRETTY_PRINT));
+
+        $this->line('manifest.json file has been created.');
+
+    }
+
+
+}

--- a/Providers/LaravelPWAServiceProvider.php
+++ b/Providers/LaravelPWAServiceProvider.php
@@ -27,6 +27,7 @@ class LaravelPWAServiceProvider extends ServiceProvider
         $this->registerViews();
         $this->registerServiceworker();
         $this->registerDirective();
+        $this->registerCommands();
     }
 
     /**
@@ -118,7 +119,19 @@ class LaravelPWAServiceProvider extends ServiceProvider
         });
     }
 
-
+    
+    /**
+     * Register the available commands
+     *
+     * @return void
+     */
+    public function registerCommands()
+    {
+        $this->commands([
+            \LaravelPWA\Console\Commands\DeployManifest::class,
+        ]);
+        
+    }
 
     /**
      * Get the services provided by the provider.


### PR DESCRIPTION
**Problem:**
If you do not change the default nginx setup (eg provided at forge) the request against manifest.json will try to access the manifest.json file in the public folder. This will result in an error and unfortunately this package is more or less "broken".

**Solution:**
Provide an artisan command "pwa:manifest-deploy" to put the output of the controller into a .json file.
That should give everbody the possibility to use this wonderful package but make use of the default file system / default nginx setup.