### PR TITLE
feat: add Description in Manifest, Displays a Shortcut Icon

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -5,6 +5,7 @@ return [
     'manifest' => [
         'name' => env('APP_NAME', 'My PWA App'),
         'short_name' => 'PWA',
+        'description' => 'PWA Description',
         'start_url' => '/',
         'background_color' => '#ffffff',
         'theme_color' => '#000000',
@@ -63,7 +64,8 @@ return [
                 'description' => 'Shortcut Link 1 Description',
                 'url' => '/shortcutlink1',
                 'icons' => [
-                    "src" => "/images/icons/icon-72x72.png",
+                    "src" => "/images/icons/icon-192x192.png",
+                    "sizes" => "192x192",
                     "purpose" => "any"
                 ]
             ],

--- a/Services/ManifestService.php
+++ b/Services/ManifestService.php
@@ -16,6 +16,7 @@ class ManifestService
         $basicManifest =  [
             'name' => config('laravelpwa.manifest.name'),
             'short_name' => config('laravelpwa.manifest.short_name'),
+            'description' => config('laravelpwa.manifest.description'),
             'start_url' => asset(config('laravelpwa.manifest.start_url')),
             'display' => config('laravelpwa.manifest.display'),
             'theme_color' => config('laravelpwa.manifest.theme_color'),
@@ -38,6 +39,7 @@ class ManifestService
         if (config('laravelpwa.manifest.shortcuts')) {
             foreach (config('laravelpwa.manifest.shortcuts') as $shortcut) {
 
+                $icon = [];
                 if (array_key_exists("icons", $shortcut)) {
                     $fileInfo = pathinfo($shortcut['icons']['src']);
                     $icon = [
@@ -46,10 +48,8 @@ class ManifestService
                         'purpose' => $shortcut['icons']['purpose']
                     ];
                     if(isset($shortcut['icons']['sizes'])) {
-                        $icon["sizes"] = $shortcut['icons']['sizes'];
+                        $icon['sizes'] = $shortcut['icons']['sizes'];
                     }
-                } else {
-                    $icon = [];
                 }
 
                 $basicManifest['shortcuts'][] = [


### PR DESCRIPTION
1. Add Description to Manifest
2. Show the Shortcut Icon

From :
![cropped](https://user-images.githubusercontent.com/56037137/147397848-439d55c9-36dc-4104-8849-c7f7662cbb89.jpeg)

To :
![cropped1](https://user-images.githubusercontent.com/56037137/147397885-e1997c2b-1701-4586-a8bd-f603d501da75.jpeg)


