### PR TITLE
translate app name

### DIFF
--- a/Services/ManifestService.php
+++ b/Services/ManifestService.php
@@ -14,8 +14,8 @@ class ManifestService
     public function generate()
     {
         $basicManifest =  [
-            'name' => config('laravelpwa.manifest.name'),
-            'short_name' => config('laravelpwa.manifest.short_name'),
+            'name' => trans(config('laravelpwa.manifest.name')),
+            'short_name' => trans(config('laravelpwa.manifest.short_name')),
             'start_url' => asset(config('laravelpwa.manifest.start_url')),
             'display' => config('laravelpwa.manifest.display'),
             'theme_color' => config('laravelpwa.manifest.theme_color'),


### PR DESCRIPTION
allows app `name` and `short_name` to be translated