### PR TITLE
fix: default value for custom config value

### DIFF
--- a/Services/ManifestService.php
+++ b/Services/ManifestService.php
@@ -63,9 +63,12 @@ class ManifestService
             }
         }
 
-        foreach (config('laravelpwa.manifest.custom') as $tag => $value) {
-             $basicManifest[$tag] = $value;
+        if (config('laravelpwa.manifest.custom')) {
+            foreach (config('laravelpwa.manifest.custom') as $tag => $value) {
+                $basicManifest[$tag] = $value;
+            }
         }
+        
         return $basicManifest;
     }
 


### PR DESCRIPTION
Fix for foreach error when there is no default value for "custom" config key in laravelpwa.php config.