### PR TITLE
Allow the middleware to be customized

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -2,6 +2,7 @@
 
 return [
     'name' => 'LaravelPWA',
+    'middleware' => ['web'],
     'manifest' => [
         'name' => env('APP_NAME', 'My PWA App'),
         'short_name' => 'PWA',

--- a/Providers/RouteServiceProvider.php
+++ b/Providers/RouteServiceProvider.php
@@ -34,7 +34,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map(Router $router)
     {
-        \Route::group(['middleware' => 'web', 'namespace' => $this->rootUrlNamespace], function()
+        \Route::group(['middleware' => config('laravelpwa.middleware', ['web']), 'namespace' => $this->rootUrlNamespace], function()
         {
             require __DIR__ . '/../Http/routes.php';
         });


### PR DESCRIPTION
This PR adds a new config setting that allows user-land to set the middleware being used in `/offline` and `/manifest.json`.

This is added for apps that doesn't use the web middleware.

```
// laravelpwa.php
return [
    'middleware' => ['web'],
];
```